### PR TITLE
Rails Tutorial ６章：ユーザー認証用としてpasswordが利用できるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails',            '5.0.3'
+gem 'bcrypt',           '3.1.11'
 gem 'bootstrap-sass',   '3.3.6'
 gem 'puma',             '3.4.0'
 gem 'sass-rails',       '5.0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
     arel (7.1.4)
     autoprefixer-rails (7.1.1.2)
       execjs
+    bcrypt (3.1.11)
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -195,6 +196,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (= 3.1.11)
   bootstrap-sass (= 3.3.6)
   byebug (= 9.0.0)
   coffee-rails (= 4.2.1)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,10 @@ class User < ApplicationRecord
             format: { with: VALID_EMAIL_REGEX },
             uniqueness: { case_sensitive: false }
 
+  validates :password,
+            presence: true,
+            length: { minimum: 6 }
+
   has_secure_password
 
 end

--- a/db/migrate/20170627060233_add_password_digest_to_users.rb
+++ b/db/migrate/20170627060233_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170627050208) do
+ActiveRecord::Schema.define(version: 20170627061347) do
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
     t.string   "email"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.string   "password_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   def setup
-    @user = User.new( name: "Example User", email: "user@example.com" )
+    @user = User.new( name: "Example User", email: "user@example.com", password: "foobar", password_confirmation: "foobar" )
   end
 
   test "should be valid" do
@@ -58,5 +58,15 @@ class UserTest < ActiveSupport::TestCase
     @user.save
     # DBに保存される段階でdowncaseされるのでreloadメソッドを呼ぶことでDBの値を得る
     assert_equal mixed_case_email.downcase, @user.reload.email
+  end
+
+  test "password should be present (nonblank)" do
+    @user.password = @user.password = @user.password_confirmation = " " * 6
+    assert_not @user.valid?
+  end
+
+  test "password should have a minimum length" do
+    @user.password = @user.password_confirmation = "a" * 5
+    assert_not @user.valid?
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -61,7 +61,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "password should be present (nonblank)" do
-    @user.password = @user.password = @user.password_confirmation = " " * 6
+    @user.password = @user.password_confirmation = " " * 6
     assert_not @user.valid?
   end
 


### PR DESCRIPTION
# 概要
- Rails Tutorial 6.3 ( https://railstutorial.jp/chapters/modeling_users?version=5.0#sec-adding_a_secure_password )以降の内容を行った
- パスワード認証周りの実装を行った

# やったこと
- Usersテーブルにpassword_digestテーブルを追加
- パスワード認証を用いるための記述をUsersModelに追加
- パスワードまわりのバリデーション
    - 空文字の拒否
    - パスワード最小長さ６文字未満の文字列を拒否
- パスワードバリデーションまわりのテストを記述